### PR TITLE
change use-db commands to use-dbkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ $ which truffle
 Similarly, aliases are created for @truffle/db-kit
 3 commands are available
 
-| command             | description                                                |
-| ------------------- | ---------------------------------------------------------- |
-| `use-db-core`       | use local developed version of `db-kit`                    |
-| `use-db-core-debug` | use local version of `db-kit` with debug inspector enabled |
-| `use-db-stable`     | use npm installed version of `db-kit`                      |
+| command                | description                                                |
+| ---------------------- | ---------------------------------------------------------- |
+| `use-dbkit-core`       | use local developed version of `db-kit`                    |
+| `use-dbkit-core-debug` | use local version of `db-kit` with debug inspector enabled |
+| `use-dbkit-stable`     | use npm installed version of `db-kit`                      |

--- a/scripts/truffle-scripts.sh
+++ b/scripts/truffle-scripts.sh
@@ -1,5 +1,5 @@
 ## Executing these functions will create aliases for truffle & db-kit
-## 
+##
 
 ## aliases
 show-truffle-env () {
@@ -25,24 +25,24 @@ use-truffle-stable () {
   unalias truffle
 }
 
-use-db-core () {
+use-dbkit-core () {
   alias db-kit=node\ ${TRUFFLE_ROOT}/packages/db-kit/dist/bin/cli.js
 }
 
-use-db-core-debug () {
+use-dbkit-core-debug () {
   alias  db-kit=node\ --inspect-brk\ ${TRUFFLE_ROOT}/packages/db-kit/dist/bin/cli.js
 }
 
-use-db-stable () {
+use-dbkit-stable () {
   unalias db-kit
 }
 
 truffle-link () {
-  if [ "$PWD" != "$TRUFFLE_ROOT" ]; then 
+  if [ "$PWD" != "$TRUFFLE_ROOT" ]; then
     echo "\e[1;31m[Warning]\e[0m This command can only be run from TRUFFLE_ROOT: $TRUFFLE_ROOT\n"
   fi
 
-  if [ $# -eq 0 ]; then 
+  if [ $# -eq 0 ]; then
     echo "usage: truffle-link pkg1 pkg2 pkg3\n"
   else
     for pkg in "$@";  do
@@ -57,7 +57,7 @@ truffle-link () {
 }
 
 truffle-unlink () {
-  if [ "$PWD" != "$TRUFFLE_ROOT" ]; then 
+  if [ "$PWD" != "$TRUFFLE_ROOT" ]; then
     echo "\e[1;31m[Warning]\e[0m This command can only be run from TRUFFLE_ROOT: $TRUFFLE_ROOT\n"
   fi
   echo "usage: truffle-unlink pkg1 pkg2 pkg3\n"


### PR DESCRIPTION
This PR changes use-db commands to be use-dbkit, as well as the readMe to reference the change. 